### PR TITLE
Add a `source-dir` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Builds and deploys a jekyll page to GitHub pages.
 Features:
 * build and test modes
 * record the site's source commit using a merge commit
+* build from any subdirectory in your repository
 * specify a target branch
 
 ## Usage
@@ -79,6 +80,21 @@ jobs:
 ```
 
 The `GH_PAGES_TOKEN` needs the `public_repo` scope to be able to trigger deployments on a public repo or the full `repo` scope to deploy a private repository. Please note that this is circumventing GitHub's protection for infinitely recursive Actions invocations, so proceed with caution!
+
+## Specifying a source directory
+
+If your site's source is not at the root of the repository, you can use the `source-dir` input to tell this action where the source can be found. For example, if your site is in a `docs/jekyll` subdirectory:
+
+```yaml
+      - name: Build & Deploy to custom branch
+        uses: DavidS/jekyll-deploy@master
+        with:
+          source-dir: docs/jekyll
+        env:
+          JEKYLL_ENV: production
+          GH_PAGES_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
+```
+
 
 ## Specifying a target branch
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: Set to "true" to only build, but not deploy. This is useful for PR testing.
     required: false
     default: "false"
+  source-dir:
+    description: Specify a subdirectory containing the jekyll site, relative to the root of the repository. If this is not specified, the site is expected to be in the root of the repository.
+    required: false
+    default: .
   target-branch:
     description: Specify the branch to deploy the site to. By default, this is "gh-pages", GitHub's default branch for doc sites.
     required: false

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -8,6 +8,8 @@ def system_or_fail(*cmd)
   exit $CHILD_STATUS unless system(*cmd)
 end
 
+Dir.chdir(ENV['INPUT_SOURCE-DIR'])
+
 system_or_fail('bundle', 'config', 'set', 'path', 'vendor/gems')
 system_or_fail('bundle', 'config', 'set', 'deployment', 'true')
 system_or_fail('bundle', 'install', '--jobs=4', '--retry=3')


### PR DESCRIPTION
This allows building sites that are not at the root of the repository.
Thanks to @roshanpal for the inspiration!