### PR TITLE
Add more logging

### DIFF
--- a/.github/workflows/jekyll-test.yml
+++ b/.github/workflows/jekyll-test.yml
@@ -19,7 +19,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Test using current SHA
-        uses: DavidS/jekyll-deploy@${{ github.sha }}
+        uses: DavidS/jekyll-deploy@${{ env.GITHUB_SHA }}
         with:
           source-dir: tests
           build-only: true
@@ -27,7 +27,7 @@ jobs:
           JEKYLL_ENV: production
 
       - name: Test deploy using current SHA
-        uses: DavidS/jekyll-deploy@${{ github.sha }}
+        uses: DavidS/jekyll-deploy@${{ env.GITHUB_SHA }}
         with:
           source-dir: tests
           target-branch: deploy

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -5,7 +5,12 @@ require 'fileutils'
 
 def system_or_fail(*cmd)
   puts "executing #{cmd.inspect}"
-  exit $CHILD_STATUS unless system(*cmd)
+  unless system(*cmd)
+    puts "execution failed with #{$CHILD_STATUS}"
+    exit $CHILD_STATUS
+  else
+    puts "executed #{cmd.inspect} successfully"
+  end
 end
 
 Dir.chdir(ENV['INPUT_SOURCE-DIR'])


### PR DESCRIPTION
In https://github.com/DavidS/jekyll-deploy/runs/1031932572?check_suite_focus=true#step:5:168 the deployment stopped without additional information.
This changes the output to report back success and failure in all cases.

This also changes how the action is referenced during testing :crossed_fingers: 