### PR TITLE
Special-case CNAME file for GitHub Pages

### DIFF
--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -15,6 +15,7 @@ end
 
 basedir = Dir.pwd
 Dir.chdir(ENV['INPUT_SOURCE-DIR'])
+sourcedir = Dir.pwd
 
 system_or_fail('bundle', 'config', 'set', 'path', 'vendor/gems')
 system_or_fail('bundle', 'config', 'set', 'deployment', 'true')
@@ -43,6 +44,12 @@ else
   puts "Didn't find target branch '#{ENV['INPUT_TARGET-BRANCH']}', using the source as a base"
   system_or_fail('git', 'reset', '--soft', "origin/source")
 end
+
+if File.exist?(File.join(sourcedir, 'CNAME')) && !File.exist?('CNAME')
+  puts "Rendering github's CNAME file"
+  FileUtils.cp(File.join(sourcedir, 'CNAME'), 'CNAME')
+end
+
 system_or_fail('git', 'add', '-A', '.')
 system_or_fail('git', 'commit', '-m', 'Update github pages')
 system_or_fail('git', 'merge', '-s', 'ours', 'origin/source')

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -5,11 +5,11 @@ require 'fileutils'
 
 def system_or_fail(*cmd)
   puts "executing #{cmd.inspect}"
-  unless system(*cmd)
+  if system(*cmd)
+    puts "executed #{cmd.inspect} successfully"
+  else
     puts "execution failed with #{$CHILD_STATUS}"
     exit $CHILD_STATUS
-  else
-    puts "executed #{cmd.inspect} successfully"
   end
 end
 


### PR DESCRIPTION
Jekyll before 4.0 does not deploy plain files. The `CNAME` file is required
for custom domains, and would be dropped without this special code.

Big thanks to @s0ph1e and @aivus for raising this and their patience in
explaining the issue to me.

Fixes #4.